### PR TITLE
Cast regex to bool before comparing it

### DIFF
--- a/models/redirect.php
+++ b/models/redirect.php
@@ -176,7 +176,7 @@ class Red_Item {
 		if ( ! $matcher )
 			return new WP_Error( 'redirect-add', __( 'Invalid source URL when creating redirect for given match type', 'redirection' ) );
 
-		$regex    = ( isset( $details['regex'] ) && $details['regex'] !== false ) ? 1 : 0;
+		$regex    = ( isset( $details['regex'] ) && (bool) $details['regex'] !== false ) ? 1 : 0;
 		$position = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}redirection_items WHERE group_id=%d", $group_id ) );
 
 		$action = $details['red_action'];


### PR DESCRIPTION
`trim()` casts the argument to `string` but the comparison on `$default['regex']` is done strictly. Therefore cast `$default['regex']` to `bool` before checking if it's `!== false`.